### PR TITLE
Fix for non-numeric chapter numbers

### DIFF
--- a/comic_dl/sites/readComicsWebsite.py
+++ b/comic_dl/sites/readComicsWebsite.py
@@ -26,7 +26,7 @@ class ReadComicsWebsite():
         return str(str(url).split("/")[4].strip().replace("_", " ").replace("-", " ").title())
 
     def single_chapter(self, comic_url, comic_name, download_directory, conversion, delete_files):
-        chapter_number = int(str(comic_url).split("/")[-1].strip())
+        chapter_number = str(comic_url).split("/")[-1].strip()
         source, cookies = globalFunctions.GlobalFunctions().page_downloader(manga_url=comic_url)
         last_chapter = int(re.findall(r'<option value="(.*?)">(.*?)</option>', str(source))[-1][-1].strip())
 
@@ -37,7 +37,7 @@ class ReadComicsWebsite():
         for image_number in range(1, last_chapter + 1):
             img_list.append("http://www.readcomics.website/uploads/manga/{0}/chapters/{1}/{2}.jpg".format(name_of_manga, chapter_number, str(image_number).zfill(2)))
 
-        file_directory = str(comic_name) + '/' + str(chapter_number) + "/"
+        file_directory = str(comic_name) + '/' + chapter_number + "/"
 
         directory_path = os.path.realpath(str(download_directory) + "/" + str(file_directory))
 


### PR DESCRIPTION
There are some chapters with non-numeric chapter numbers, i.e. http://readcomics.website/comic/dc-comics-rebirth/aquaman-rebirth. Removing the int conversion fixes getting those.