### PR TITLE
fixes: mangaFox chapter list is in reverse order, make it work with "…

### DIFF
--- a/comic_dl/sites/mangaFox.py
+++ b/comic_dl/sites/mangaFox.py
@@ -111,7 +111,7 @@ class MangaFox(object):
 
             indexes = [x for x in range(starting, ending)]
 
-            all_links = [all_links[x] for x in indexes][::-1]
+            all_links = [all_links[len(all_links) - 1 - x] for x in indexes][::-1]
             # if chapter range contains "__EnD__" write new value to config.json
             if chapter_range.split("-")[1] == "__EnD__":
                 globalFunctions.GlobalFunctions().saveNewRange(comic_url,len(all_links))
@@ -120,7 +120,8 @@ class MangaFox(object):
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(comic_url=str(chap_link), comic_name=comic_name, conversion=conversion,
+                self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
+                                    download_directory=download_directory, conversion=conversion,
                                     delete_files=delete_files)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:


### PR DESCRIPTION
fix1: missing arg in function

fix2: mangaFox chapter list is in reverse order, make it work with __main__.py --auto, 
Example: the following config.json was downloading the x *first* chapters instead of the x last chapters
{
    "download_directory": "dire", 
    "comics": {
        "http://mangafox.me/manga/enen_no_shouboutai": {
            "url": "http://mangafox.me/manga/enen_no_shouboutai", 
            "username": "None", 
            "comic_language": "0", 
            "password": "None", 
            "next": 110
        }
    }, 
    "conversion": "cbz", 
    "keep": "True", 
    "sorting_order": "ascending", 
    "image_quality": "Best"
}