### PR TITLE
fix input compability of python 2 input and python 3 input

### DIFF
--- a/comic_dl/configGenerator.py
+++ b/comic_dl/configGenerator.py
@@ -1,6 +1,7 @@
 # @dsanchezseco
 import os
 import json
+from builtins import input
 
 
 CONFIG_FILE="config.json"
@@ -49,7 +50,7 @@ class configGenerator(object):
         print
 
         print("download directory (default '<here>/comics')")
-        data['download_directory'] = input(" >> ")
+        data["download_directory"] = input(" >> ")
         print("sorting order (default 'ascending')")
         data["sorting_order"] = input("[ ascending | descending ] >> ")
         print("conversion (default 'none')")
@@ -62,8 +63,8 @@ class configGenerator(object):
         # check mandatories and defaults
         if not data["sorting_order"]:
             data["sorting_order"] = "ascending"
-        if not data['download_directory']:
-            data['download_directory'] = "comics"
+        if not data["download_directory"]:
+            data["download_directory"] = "comics"
         if not data["keep"]:
             data["keep"] = "True"
         if not data["conversion"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cfscrape
 clint
 img2pdf
 enum34
+future


### PR DESCRIPTION
I tested today again with python2 and the behavior of input is different in py2 so that library must be imported to have the same behavior in both versions, its added on the `requirements.txt` too. So users already using it should relaunch the 
```pip install -r requirements.txt```