### PR TITLE
fix, stop chapters download when mangafox page doesn't contain images.

### DIFF
--- a/comic_dl/sites/mangaFox.py
+++ b/comic_dl/sites/mangaFox.py
@@ -116,7 +116,9 @@ class MangaFox(object):
                     self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
                                     download_directory=download_directory, conversion=conversion,
                                     delete_files=delete_files)
-                except:
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    logging.error(ex)
                     break  # break to continue processing other mangas when chapter doesn't contain images.
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range.split("-")[1] == "__EnD__":
@@ -128,7 +130,9 @@ class MangaFox(object):
                     self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
                                         download_directory=download_directory, conversion=conversion,
                                         delete_files=delete_files)
-                except:
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    logging.error(ex)
                     break  # break to continue processing other mangas when chapter doesn't contain images.
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range.split("-")[1] == "__EnD__":

--- a/comic_dl/sites/mangaFox.py
+++ b/comic_dl/sites/mangaFox.py
@@ -112,18 +112,24 @@ class MangaFox(object):
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
+                try:
+                    self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
                                     download_directory=download_directory, conversion=conversion,
                                     delete_files=delete_files)
+                except:
+                    break  # break to continue processing other mangas when chapter doesn't contain images.
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
-                self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
-                                    download_directory=download_directory, conversion=conversion,
-                                    delete_files=delete_files)
+                try:
+                    self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
+                                        download_directory=download_directory, conversion=conversion,
+                                        delete_files=delete_files)
+                except:
+                    break  # break to continue processing other mangas when chapter doesn't contain images.
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)


### PR DESCRIPTION
for example:

http://fanfox.net/manga/gunnm_mars_chronicle/c029.1/1.html

in that case, when using 
`         __main__.py -a`
comic-dl exits with an error.
I made changes to stop the download for that manga but continue processing the remaining comics/mangas