### PR TITLE
fix #189 Feature Request: Crash on 502

### DIFF
--- a/comic_dl/globalFunctions.py
+++ b/comic_dl/globalFunctions.py
@@ -75,7 +75,7 @@ class GlobalFunctions(object):
             sess = cfscrape.create_scraper(sess)
             try:
                 r = sess.get(image_ddl, stream=True, headers=headers, cookies=kwargs.get("cookies"))
-
+                r.raise_for_status()
                 if r.status_code != 200:
                     pbar.write("Could not download the image.")
                     pbar.write("Link said : %s" % r.status_code)
@@ -94,10 +94,26 @@ class GlobalFunctions(object):
                         pbar.write(file_moving_exception)
                         os.remove(file_path)
                         raise file_moving_exception
+            except requests.exceptions.HTTPError as errh:
+                pbar.write("Http Error:")
+                pbar.write(errh.message)
+                raise
+            except requests.exceptions.ConnectionError as errc:
+                pbar.write("Error Connecting:")
+                pbar.write(errc.message)
+                raise
+            except requests.exceptions.Timeout as errt:
+                pbar.write("Timeout Error:")
+                pbar.write(errt.message)
+                raise
+            except requests.exceptions.RequestException as err:
+                pbar.write("OOps: Something Else")
+                pbar.write(err.message)
+                raise
             except Exception as ex:
-                pbar.write("Some problem occurred while downloading this image")
+                pbar.write("Some problem occurred while downloading this image: %s " % file_name)
                 pbar.write(ex)
-                raise ex
+                raise
 
         pbar.update()
 

--- a/comic_dl/sites/batoto.py
+++ b/comic_dl/sites/batoto.py
@@ -204,16 +204,24 @@ class Batoto:
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(comic_url=chap_link, download_directory=download_directory, conversion=conversion,
-                                    keep_files=keep_files, session_cookies=session_cookie)
+                try:
+                    self.single_chapter(comic_url=chap_link, download_directory=download_directory,
+                                        conversion=conversion,
+                                        keep_files=keep_files, session_cookies=session_cookie)
+                except Exception as ex:
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
-                self.single_chapter(comic_url=chap_link, download_directory=download_directory, conversion=conversion,
-                                    keep_files=keep_files, session_cookies=session_cookie)
+                try:
+                    self.single_chapter(comic_url=chap_link, download_directory=download_directory,
+                                        conversion=conversion,
+                                        keep_files=keep_files, session_cookies=session_cookie)
+                except Exception as ex:
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/comicNaver.py
+++ b/comic_dl/sites/comicNaver.py
@@ -106,16 +106,26 @@ class ComicNaver(object):
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             # print("Running this")
             for chap_link in all_links[::-1]:
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/comicextra.py
+++ b/comic_dl/sites/comicextra.py
@@ -119,11 +119,12 @@ class ComicExtra(object):
                 try:
                     self.single_chapter(comic_url=chap_link, download_directory=download_directory,
                                         conversion=conversion, keep_files=keep_files)
-                    # if chapter range contains "__EnD__" write new value to config.json
-                    if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
-                        globalFunctions.GlobalFunctions().addOne(comic_url)
-                except Exception as e:
-                    pass
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
+                # if chapter range contains "__EnD__" write new value to config.json
+                if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
+                    globalFunctions.GlobalFunctions().addOne(comic_url)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
@@ -131,10 +132,11 @@ class ComicExtra(object):
                 try:
                     self.single_chapter(comic_url=chap_link, download_directory=download_directory,
                                         conversion=conversion, keep_files=keep_files)
-                    # if chapter range contains "__EnD__" write new value to config.json
-                    if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
-                        globalFunctions.GlobalFunctions().addOne(comic_url)
-                except Exception as e:
-                    pass
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
+                # if chapter range contains "__EnD__" write new value to config.json
+                if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
+                    globalFunctions.GlobalFunctions().addOne(comic_url)
 
         return 0

--- a/comic_dl/sites/foolSlide.py
+++ b/comic_dl/sites/foolSlide.py
@@ -117,16 +117,26 @@ class FoolSlide(object):
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(chapter_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(chapter_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(manga_url)
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             # print("Running this")
             for chap_link in all_links[::-1]:
-                self.single_chapter(chapter_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(chapter_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(manga_url)

--- a/comic_dl/sites/hqbr.py
+++ b/comic_dl/sites/hqbr.py
@@ -108,8 +108,9 @@ class Hqbr(object):
                     # if chapter range contains "__EnD__" write new value to config.json
                     if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                         globalFunctions.GlobalFunctions().addOne(comic_url)
-                except Exception as e:
-                    pass
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
@@ -120,7 +121,8 @@ class Hqbr(object):
                     # if chapter range contains "__EnD__" write new value to config.json
                     if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                         globalFunctions.GlobalFunctions().addOne(comic_url)
-                except Exception as e:
-                    pass
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
 
         return 0

--- a/comic_dl/sites/mangaHere.py
+++ b/comic_dl/sites/mangaHere.py
@@ -139,18 +139,26 @@ class MangaHere(object):
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in chapter_links:
-                self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
-                                    download_directory=download_directory, conversion=conversion,
-                                    keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
+                                        download_directory=download_directory, conversion=conversion,
+                                        keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in chapter_links[::-1]:
-                self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
-                                    download_directory=download_directory, conversion=conversion,
-                                    keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=str(chap_link), comic_name=comic_name,
+                                        download_directory=download_directory, conversion=conversion,
+                                        keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/mangaReader.py
+++ b/comic_dl/sites/mangaReader.py
@@ -138,16 +138,26 @@ class MangaReader():
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/mangaRock.py
+++ b/comic_dl/sites/mangaRock.py
@@ -31,7 +31,7 @@ class MangaRock():
 
     def name_cleaner(self, url, chapter_id):
         print("Fetching The Chapter Data...")
-        info_json_url = "https://api.mangarockhd.com/query/web400/info?oid=" + str(str(url).split("/")[4])
+        info_json_url = "https://api.mangarockhd.com/query/web401/info?oid=" + str(str(url).split("/")[4])
 
         source, cookies = globalFunctions.GlobalFunctions().page_downloader(manga_url=info_json_url)
         json_parse = json.loads(str(source))
@@ -67,7 +67,7 @@ class MangaRock():
             os.remove(mri_file)
 
     def single_chapter(self, chapter_id, comic_name, chapter_number, download_directory, conversion, keep_files):
-        image_api_link = "https://api.mangarockhd.com/query/web400/pages?oid=" + str(chapter_id)
+        image_api_link = "https://api.mangarockhd.com/query/web401/pages?oid=" + str(chapter_id)
         source, cookies = globalFunctions.GlobalFunctions().page_downloader(manga_url=image_api_link)
         json_parse = json.loads(str(source))
 
@@ -101,7 +101,7 @@ class MangaRock():
 
     def full_series(self, comic_id, sorting, download_directory, chapter_range, conversion, keep_files):
         chapters_dict = {}
-        api_url = "https://api.mangarockhd.com/query/web400/info?oid=" + str(comic_id)
+        api_url = "https://api.mangarockhd.com/query/web401/info?oid=" + str(comic_id)
 
         source, cookies = globalFunctions.GlobalFunctions().page_downloader(manga_url=api_url)
         json_parse = json.loads(str(source))

--- a/comic_dl/sites/mangaRock.py
+++ b/comic_dl/sites/mangaRock.py
@@ -132,10 +132,13 @@ class MangaRock():
             return
 
         for single_chapter in chapters_dict:
-            self.single_chapter(chapter_id=str(single_chapter), comic_name=comic_name,
-                                chapter_number=str(chapters_dict[single_chapter]).strip().title(),
-                                download_directory=download_directory, conversion=conversion,
-                                keep_files=keep_files)
+            try:
+                self.single_chapter(chapter_id=str(single_chapter), comic_name=comic_name,
+                                    chapter_number=str(chapters_dict[single_chapter]).strip().title(),
+                                    download_directory=download_directory, conversion=conversion,
+                                    keep_files=keep_files)
+            except Exception as ex:
+                break  # break to continue processing other mangas
             if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                 globalFunctions.GlobalFunctions().addOne(self.manga_url)
 

--- a/comic_dl/sites/omgBeauPeep.py
+++ b/comic_dl/sites/omgBeauPeep.py
@@ -106,5 +106,9 @@ class OmgBeauPeep(object):
                 if bypass_first:  # Because this website lists the next chapter, which is NOT available.
                     bypass_first = False
                     continue
-                self.single_chapter(manga_url + "/" + str(option['value']), comic_name, download_directory, conversion=conversion,
-                                keep_files=keep_files)
+                try:
+                    self.single_chapter(manga_url + "/" + str(option['value']), comic_name, download_directory, conversion=conversion,
+                                    keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % str(option['value']))
+                    break  # break to continue processing other mangas

--- a/comic_dl/sites/rawSenManga.py
+++ b/comic_dl/sites/rawSenManga.py
@@ -118,8 +118,12 @@ class RawSenaManga(object):
             for link in all_links:
                 chap_link = "http://raw.senmanga.com/" + str(series_name_raw) + "/" + str(
                     link).strip()
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
@@ -128,8 +132,13 @@ class RawSenaManga(object):
             for link in all_links[::-1]:
                 chap_link = "http://raw.senmanga.com/" + str(series_name_raw) + "/" + str(
                     link).strip()
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/readComicBooksOnline.py
+++ b/comic_dl/sites/readComicBooksOnline.py
@@ -128,8 +128,8 @@ class ReadComicBooksOnline():
                     # if chapter range contains "__EnD__" write new value to config.json
                     if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                         globalFunctions.GlobalFunctions().addOne(comic_url)
-                except Exception as e:
-                    pass
+                except Exception as ex:
+                    break  # break to continue processing other mangas
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
@@ -141,6 +141,6 @@ class ReadComicBooksOnline():
                     if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                         globalFunctions.GlobalFunctions().addOne(comic_url)
                 except Exception as e:
-                    pass
+                    break  # break to continue processing other mangas
 
         return 0

--- a/comic_dl/sites/readComicsIO.py
+++ b/comic_dl/sites/readComicsIO.py
@@ -110,7 +110,7 @@ class ReadComicsIO():
                     if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                         globalFunctions.GlobalFunctions().addOne(comic_url)
                 except Exception as e:
-                    pass
+                    break  # break to continue processing other mangas
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
@@ -122,6 +122,6 @@ class ReadComicsIO():
                     if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                         globalFunctions.GlobalFunctions().addOne(comic_url)
                 except Exception as e:
-                    pass
+                    break  # break to continue processing other mangas
 
         return 0

--- a/comic_dl/sites/readComicsWebsite.py
+++ b/comic_dl/sites/readComicsWebsite.py
@@ -98,16 +98,24 @@ class ReadComicsWebsite():
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
 
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/readcomicOnlineto.py
+++ b/comic_dl/sites/readcomicOnlineto.py
@@ -138,8 +138,12 @@ class ReadComicOnlineTo(object):
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:
             for chap_link in all_links:
                 chap_link = "http://readcomiconline.to" + chap_link
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
@@ -147,8 +151,12 @@ class ReadComicOnlineTo(object):
         elif str(sorting).lower() in ['old', 'asc', 'ascending', 'oldest', 'a']:
             for chap_link in all_links[::-1]:
                 chap_link = "http://readcomiconline.to" + chap_link
-                self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(comic_url=chap_link, comic_name=comic_name, download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)

--- a/comic_dl/sites/stripUtopia.py
+++ b/comic_dl/sites/stripUtopia.py
@@ -98,9 +98,13 @@ class StripUtopia(object):
             for chap_link in all_links:
                 page_souce, cookies_main = globalFunctions.GlobalFunctions().page_downloader(
                     manga_url=chap_link + ".html")
-                self.single_chapter(source=page_souce, comic_url=chap_link + ".html", comic_name=comic_name,
-                                    download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(source=page_souce, comic_url=chap_link + ".html", comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)
@@ -109,9 +113,13 @@ class StripUtopia(object):
             for chap_link in all_links[::-1]:
                 page_souce, cookies_main = globalFunctions.GlobalFunctions().page_downloader(
                     manga_url=chap_link + ".html")
-                self.single_chapter(source=page_souce, comic_url=chap_link + ".html", comic_name=comic_name,
-                                    download_directory=download_directory,
-                                    conversion=conversion, keep_files=keep_files)
+                try:
+                    self.single_chapter(source=page_souce, comic_url=chap_link + ".html", comic_name=comic_name,
+                                        download_directory=download_directory,
+                                        conversion=conversion, keep_files=keep_files)
+                except Exception as ex:
+                    logging.error("Error downloading : %s" % chap_link)
+                    break  # break to continue processing other mangas
                 # if chapter range contains "__EnD__" write new value to config.json
                 if chapter_range != "All" and chapter_range.split("-")[1] == "__EnD__":
                     globalFunctions.GlobalFunctions().addOne(comic_url)


### PR DESCRIPTION
fix #189 Feature Request: Crash on 502

I think this shouldn't be a switch (as requested) but the default behaviour for http error codes 4xx and 5xx. It will stop the download for remaining chapters.

in auto download mode, this will stop the download of the remaining chapters for the current manga and will continue with the next manga in the list.