### PR TITLE
Removed python2 style print statement that makes python3 execution crash

### DIFF
--- a/comic_dl/sites/acQQ.py
+++ b/comic_dl/sites/acQQ.py
@@ -125,7 +125,7 @@ class AcQq(object):
             idx = 0
             for chap_link in all_links:
                 idx = idx + 1
-                print str(idx) + ": " + str(chap_link)
+                print(str(idx) + ": " + str(chap_link))
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:

--- a/comic_dl/sites/batoto.py
+++ b/comic_dl/sites/batoto.py
@@ -198,7 +198,7 @@ class Batoto:
         if self.print_index:
             idx = len(all_links)
             for chap_link in all_links:
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
                 idx = idx - 1
             return
 

--- a/comic_dl/sites/comicNaver.py
+++ b/comic_dl/sites/comicNaver.py
@@ -101,7 +101,7 @@ class ComicNaver(object):
             idx = 0
             for chap_link in all_links:
                 idx = idx + 1
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:

--- a/comic_dl/sites/comicextra.py
+++ b/comic_dl/sites/comicextra.py
@@ -109,7 +109,7 @@ class ComicExtra(object):
         if self.print_index:
             idx = len(all_links)
             for chap_link in all_links:
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
                 idx = idx - 1
             return
 

--- a/comic_dl/sites/hqbr.py
+++ b/comic_dl/sites/hqbr.py
@@ -95,7 +95,7 @@ class Hqbr(object):
         if self.print_index:
             idx = len(all_links)
             for chap_link in all_links:
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
                 idx = idx -1
             return
 

--- a/comic_dl/sites/mangaFox.py
+++ b/comic_dl/sites/mangaFox.py
@@ -116,7 +116,7 @@ class MangaFox(object):
         if self.print_index:
             idx = len(all_links)
             for chap_link in all_links:
-                print str(idx) + ": " + str(chap_link)
+                print(str(idx) + ": " + str(chap_link))
                 idx = idx - 1
             return
 

--- a/comic_dl/sites/mangaHere.py
+++ b/comic_dl/sites/mangaHere.py
@@ -133,7 +133,7 @@ class MangaHere(object):
         if self.print_index:
             idx = chapter_links.__len__()
             for chap_link in chapter_links:
-                print str(idx) + ": " + str(chap_link)
+                print(str(idx) + ": " + str(chap_link))
                 idx = idx - 1
             return
 

--- a/comic_dl/sites/mangaReader.py
+++ b/comic_dl/sites/mangaReader.py
@@ -133,7 +133,7 @@ class MangaReader():
             idx = 0
             for chap_link in all_links:
                 idx = idx + 1
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:

--- a/comic_dl/sites/mangaRock.py
+++ b/comic_dl/sites/mangaRock.py
@@ -128,7 +128,7 @@ class MangaRock():
         if self.print_index:
             chapters_ = json_parse["data"]["chapters"]
             for chapter in chapters_:
-                print str(chapter["order"] + 1) + ": " + chapter["name"].encode('utf-8')
+                print(str(chapter["order"] + 1) + ": " + chapter["name"].encode('utf-8'))
             return
 
         for single_chapter in chapters_dict:

--- a/comic_dl/sites/omgBeauPeep.py
+++ b/comic_dl/sites/omgBeauPeep.py
@@ -53,7 +53,7 @@ class OmgBeauPeep(object):
 
         if self.print_index:
             for x in xrange(1, last_page_number + 1):
-                print str(x) + ": " + str(comic_url) + "/" + str(x)
+                print(str(x) + ": " + str(comic_url) + "/" + str(x))
             return
 
         if not os.path.exists(directory_path):
@@ -101,7 +101,7 @@ class OmgBeauPeep(object):
         bypass_first = "otakusmash" in manga_url
         for option in chapters.findAll('option'):
             if self.print_index:
-                print '{}: {}'.format(option['value'], option.text)
+                print('{}: {}'.format(option['value'], option.text))
             else:
                 if bypass_first:  # Because this website lists the next chapter, which is NOT available.
                     bypass_first = False

--- a/comic_dl/sites/rawSenManga.py
+++ b/comic_dl/sites/rawSenManga.py
@@ -110,7 +110,7 @@ class RawSenaManga(object):
             all_links = list(re.findall(link_regex, str(source)))
             idx = len(all_links)
             for link in all_links:
-                print str(idx) + ": " + link
+                print(str(idx) + ": " + link)
                 idx = idx - 1
             return
 

--- a/comic_dl/sites/readComicBooksOnline.py
+++ b/comic_dl/sites/readComicBooksOnline.py
@@ -115,7 +115,7 @@ class ReadComicBooksOnline():
         if self.print_index:
             idx = len(all_links)
             for chap_link in all_links:
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
                 idx = idx - 1
             return
 

--- a/comic_dl/sites/readComicsIO.py
+++ b/comic_dl/sites/readComicsIO.py
@@ -97,7 +97,7 @@ class ReadComicsIO():
             idx = 0
             for chap_link in all_links:
                 idx = idx + 1
-                print str(idx) + ": " + str(chap_link)
+                print(str(idx) + ": " + str(chap_link))
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:

--- a/comic_dl/sites/readComicsWebsite.py
+++ b/comic_dl/sites/readComicsWebsite.py
@@ -93,7 +93,7 @@ class ReadComicsWebsite():
             idx = 0
             for chap_link in all_links:
                 idx = idx + 1
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:

--- a/comic_dl/sites/readcomicOnlineto.py
+++ b/comic_dl/sites/readcomicOnlineto.py
@@ -132,7 +132,7 @@ class ReadComicOnlineTo(object):
             idx = 0
             for chap_link in all_links:
                 idx = idx + 1
-                print str(idx) + ": " + chap_link
+                print(str(idx) + ": " + chap_link)
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:

--- a/comic_dl/sites/stripUtopia.py
+++ b/comic_dl/sites/stripUtopia.py
@@ -91,7 +91,7 @@ class StripUtopia(object):
             all_chapters = re.findall(r'http://striputopija.blogspot.rs/\d+/\d+/.+.html.+>(.+)</a>', str(source))
             for chap_link in all_chapters:
                 idx = idx + 1
-                print str(idx) + ": " + str(chap_link)
+                print(str(idx) + ": " + str(chap_link))
             return
 
         if str(sorting).lower() in ['new', 'desc', 'descending', 'latest']:


### PR DESCRIPTION
Multiple python2 style print statements are changed into python3 style statements.  This prevents the program from crashing when run on python3 interpreter.