### PR TITLE
fix cbz creation when the archive path is an absolute path

### DIFF
--- a/comic_dl/globalFunctions.py
+++ b/comic_dl/globalFunctions.py
@@ -157,7 +157,7 @@ class GlobalFunctions(object):
                     print('[Comic-dl] CBZ File Exist! Skipping : {0}\n'.format(cbz_file_name))
                     pass
                 else:
-                    shutil.make_archive(cbz_file_name, 'zip', directory_path, directory_path)
+                    shutil.make_archive(cbz_file_name, 'zip', directory_path)
                     os.rename(str(cbz_file_name) + ".zip", (str(cbz_file_name)+".zip").replace(".zip", ".cbz"))
             except Exception as CBZError:
                 print("Couldn't write the cbz file...")


### PR DESCRIPTION
as per documentation ( https://docs.python.org/3.8/library/os.path.htmlhttps://docs.python.org/3.8/library/shutil.html#archiving-operations  https://docs.python.org/3.8/library/shutil.html#archiving-example)
the first path already chdirs into the full path, the second is used to
create the internal archive path, if a full absolute path is passed
again it creates an internal path in the format of /too/long/path/1.jpg, which several
cbz readers cannot make use of
fixes #216 