### PR TITLE
cfscrape -> cloudscraper

### DIFF
--- a/comic_dl/globalFunctions.py
+++ b/comic_dl/globalFunctions.py
@@ -72,7 +72,7 @@ class GlobalFunctions(object):
             }
 
             sess = requests.session()
-            sess = cfscrape.create_scraper(sess)
+            sess = cloudscraper.create_scraper(sess)
             try:
                 r = sess.get(image_ddl, stream=True, headers=headers, cookies=kwargs.get("cookies"))
                 r.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 tqdm
 bs4
 requests
-cfscrape
 clint
 img2pdf
 enum34


### PR DESCRIPTION
This fixes the error `name 'cfscrape' is not defined` introduced by the incomplete migration to cloudscraper in 2104c1481f7b8e87608e8137c75555fc6da08ea8.