### PR TITLE
Fix docker build by upgrading pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -yq upgrade
 # update system & install basisc stuff
 #        and dependencies for phantomjs
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-    build-essential chrpath libssl-dev libxft-dev \
-         libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
-    wget nodejs-legacy
+    build-essential \
+    chrpath \
+    libssl-dev \
+    libxft-dev \
+    libfreetype6 \
+    libfreetype6-dev \
+    libfontconfig1 \
+    libfontconfig1-dev
+    #wget nodejs-legacy
 
 # We're not using PhantomJS anymore. So, this step should be removed for now.
 # install phantomjs and symlink to /usr/local/bin/
@@ -15,8 +21,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 #    ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/
 
 # This install comic-dl and symlink to comic_dl command
+
 FROM base
 COPY / /opt/comic-dl
-RUN python -m pip install -r /opt/comic-dl/requirements.txt && \
+RUN python -m pip install --upgrade pip && \
+    python -m pip install -r /opt/comic-dl/requirements.txt && \
     chmod +x /opt/comic-dl/comic_dl/__main__.py  && \
     ln -s /opt/comic-dl/comic_dl/__main__.py /usr/local/bin/comic_dl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # this buld the base image to run comic_dl
-FROM python:3.6.5-stretch AS base
+FROM python:3.6.5-slim-stretch AS base
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -yq upgrade
 # update system & install basisc stuff
 #        and dependencies for phantomjs
@@ -21,8 +21,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 #    ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/
 
 # This install comic-dl and symlink to comic_dl command
-
-FROM base
 COPY / /opt/comic-dl
 RUN python -m pip install --upgrade pip && \
     python -m pip install -r /opt/comic-dl/requirements.txt && \


### PR DESCRIPTION
Hi, 

First of all thanks for the great job on this project !

I built the docker image from master branch and ended up getting an error.
```
Command "/usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-aki3wasa/pikepdf/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-peaingry/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-install-aki3wasa/pikepdf/
You are using pip version 10.0.1, however version 20.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c python -m pip install -r /opt/comic-dl/requirements.txt &&     chmod +x /opt/comic-dl/comic_dl/__main__.py  &&     ln -s /opt/comic-dl/comic_dl/__main__.py /usr/local/bin/comic_dl' returned a non-zero code: 1
```

I included a quick fix for this, commented out unused packages, and switched to `python:3.6.5-slim-stretch` base image to make the built image a bit lighter.
I also removed this line :
```
FROM base
```
In the current state of the Dockerfile I don't think this line is useful. There is no multi-stage build as only one image is used and produced by the build for now.

I'm also interested in fixing this error (it appears when running comic_dl from within the built image) :
```
DEPRECATION: The OpenSSL being used by this python install (OpenSSL 1.1.0l  10 Sep 2019) does not meet the minimum supported version (>= OpenSSL 1.1.1) in order to support TLS 1.3 required by Cloudflare, You may encounter an unexpected Captcha or cloudflare 1020 blocks.
```
After digging a bit I suspect this has to do with the cloudscraper package, but couldn't find any indications on the project as how to fix this. I can implement a solution if anyone knows where I should look for this.

Let me know if I can help get this merged faster. :)

