### PR TITLE
Fix typo in `.dockerignore`; `git` is supposed to be `.git`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-git
+.git
 .gitignore
 Dockerfile*
 docker-compose*


### PR DESCRIPTION
Hi Xonshiz.

I am tinkering with the Docker image of this program at the moment and noticed there is possibly a typo. 
Adding `.git` inside `.dockerignore` shaves off about 60MB from the image.

P.S. I believe I have an Alpine Linux based image that is ready for beta testing. I will make a PR about that shortly, after I test out a few other things. Long story short, I managed to get it down to about ~100MB (almost 2/3rd size reduction).

(I have so far tested out downloading manga, and it works :smile_cat: )

```
localhost/msl-comic-dl             latest           a7ba8426afb1  32 minutes ago  94.9 MB
localhost/comic-dl                 py3.8-buster     b4bf0219d6f1  23 hours ago    285 MB
```