### PR TITLE
move py3.8-slim-buster-pikepdf to its own docker image for arm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ on:
       - '.gitattributes'
       - '.gitignore'
       - '.dockerignore'
-      
+
   pull_request:
     branches: [ master ]
     
@@ -32,12 +32,18 @@ on:
       - '.gitignore'
       - '.dockerignore'
 
+
+# TODO change to sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+# when PR fix for lowercase is merged
 jobs:
   build_and_push:
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+    uses: darodi/common-github-workflows/.github/workflows/build_and_push_image.yml@main
     with:
+      platform_linux_arm32v6_enabled: true
       platform_linux_arm32v7_enabled: true
-      platform_linux_arm64v8_enabled: false
+      platform_linux_arm64v8_enabled: true
+      platform_linux_amd64_enabled: true
+      platform_linux_i386_enabled: false
       push_enabled: true
       ghcr_repo_owner: ${{ github.repository_owner }}
       ghcr_repo: ${{ github.repository }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,18 +19,18 @@ on:
       - '.gitignore'
       - '.dockerignore'
 
-  pull_request:
-    branches: [ master ]
-    
-    # Don't trigger if it's just a documentation update
-    paths-ignore:
-      - '**.md'
-      - '**.MD'
-      - '**.yml'
-      - 'LICENSE'
-      - '.gitattributes'
-      - '.gitignore'
-      - '.dockerignore'
+#  pull_request:
+#    branches: [ master ]
+#
+#    # Don't trigger if it's just a documentation update
+#    paths-ignore:
+#      - '**.md'
+#      - '**.MD'
+#      - '**.yml'
+#      - 'LICENSE'
+#      - '.gitattributes'
+#      - '.gitignore'
+#      - '.dockerignore'
 
 
 # TODO change to sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # alias comic_dl="docker run -it --rm -e PGID=$(id -g) -e PUID=$(id -u) -v $(pwd):/directory:rw -w /directory comic-dl:py3.8-buster comic_dl -dd /directory"
 
 # for armv7,
-# cross build it (it takes a few hours on x86_64), or be prepared to wait an eternity
+# cross build it (it takes a few hours on x86_64)
 # build with command:
 # docker build -t comic-dl:py3.8-buster-armv7 --platform linux/arm/v7 .
 # export with command
@@ -14,82 +14,7 @@
 # run with alias:
 # alias comic_dl="docker run -it --rm -e PGID=$(id -g) -e PUID=$(id -u) -v $(pwd):/directory:rw -w /directory comic-dl:py3.8-buster-armv7 comic_dl -dd /directory"
 
-FROM --platform=linux/amd64 python:3.8-slim-buster as stage-amd64
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yq upgrade
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
-RUN echo "I'm building for $TARGETOS/$TARGETARCH/$TARGETVARIANT"
-
-FROM --platform=linux/arm/v7 python:3.8-slim-buster as stage-armv7
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
-RUN echo "I'm building for $TARGETOS/$TARGETARCH/$TARGETVARIANT"
-
-ENV LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8 \
-    LANGUAGE=en_US:en
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-## qpdf and pikepdf need to be built from source on armv7
-RUN set -x && \
-    TEMP_PACKAGES=() && \
-    KEPT_PACKAGES=() && \
-    # Packages only required during build
-    TEMP_PACKAGES+=(git) && \
-    TEMP_PACKAGES+=(make) && \
-    TEMP_PACKAGES+=(build-essential) && \
-    TEMP_PACKAGES+=(libssl-dev) && \
-    TEMP_PACKAGES+=(libfreetype6-dev) && \
-    TEMP_PACKAGES+=(libfontconfig1-dev) && \
-    TEMP_PACKAGES+=(libjpeg-dev) && \
-    TEMP_PACKAGES+=(libqpdf-dev) && \
-    TEMP_PACKAGES+=(libxft-dev) && \
-    TEMP_PACKAGES+=(libxml2-dev) && \
-    TEMP_PACKAGES+=(libxslt1-dev) && \
-    TEMP_PACKAGES+=(zlib1g-dev) && \
-    # Packages kept in the image
-    KEPT_PACKAGES+=(bash) && \
-    KEPT_PACKAGES+=(ca-certificates) && \
-    KEPT_PACKAGES+=(locales) && \
-    KEPT_PACKAGES+=(locales-all) && \
-    KEPT_PACKAGES+=(python3) && \
-    TEMP_PACKAGES+=(python3-dev) && \
-    KEPT_PACKAGES+=(python3-pip) && \
-    KEPT_PACKAGES+=(chrpath) && \
-    KEPT_PACKAGES+=(libfreetype6) && \
-    KEPT_PACKAGES+=(libfontconfig1) && \
-    KEPT_PACKAGES+=(python3-wheel) && \
-    # Install packages
-    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get -yq upgrade && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ${KEPT_PACKAGES[@]} \
-        ${TEMP_PACKAGES[@]} \
-        && \
-    git config --global advice.detachedHead false && \
-    # Install required python modules
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir pybind11 && \
-    ## qpdf and pikepdf need to be built from source on armv7
-    cd /opt \
-    && git clone --branch release-qpdf-10.6.3 https://github.com/qpdf/qpdf.git \
-    && git clone --branch v5.1.1 https://github.com/pikepdf/pikepdf.git \
-    && cd /opt/qpdf \
-    && ./configure \
-    && make \
-    && make install \
-    && cd /opt/pikepdf \
-    && pip install . && \
-    # Clean-up
-    DEBIAN_FRONTEND=noninteractive apt-get remove -y ${TEMP_PACKAGES[@]} && \
-    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /src /opt/qpdf /opt/pikepdf
-
-# Select final stage based on TARGETARCH ARG
-FROM stage-${TARGETARCH}${TARGETVARIANT} as final
+FROM ghcr.io/darodi/docker-py3.8-slim-buster-pikepdf:latest
 
 COPY / /opt/comic-dl
 RUN python -m pip install --upgrade pip && \


### PR DESCRIPTION
move py3.8-slim-buster-pikepdf to its own docker image for arm

I also changed  the workflow used to work with Upercase github username/repository name
It uses: darodi/common-github-workflows/.github/workflows/build_and_push_image.yml@main

to prevent error:
   Error: buildx failed with: error: invalid tag "ghcr.io/Xonshiz/comic-dl:2022.04.09_linux_amd64_nohealthcheck": repository name must be lowercase