### PR TITLE
Added shebang to ./cli.py to make the file executable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 from comic_dl.__main__ import main
 


### PR DESCRIPTION
Hi, I added the Python shebang (`#!/usr/bin/env python`) to `./cli.py` to make the file executable on Linux systems.

Before that, you had to type `python ./cli.py` instead of just `./cli.py` because Linux would assume the file is binary code instead.